### PR TITLE
Include notification task with include_role instead of include_tasks

### DIFF
--- a/tasks/activate.yml
+++ b/tasks/activate.yml
@@ -39,7 +39,8 @@
                            --profile '{{ aws_profile }}'
 
         - name: call optional notifier
-          include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+          include_role:
+            name: '{{ notifier_role }}'
           vars:
             message: >
               updated the Default trail in
@@ -73,7 +74,8 @@
                        --profile '{{ aws_profile }}'
 
     - name: call optional notifier
-      include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+      include_role:
+        name: '{{ notifier_role }}'
       vars:
         message: >
           created the Default trail in
@@ -105,7 +107,8 @@
                        --profile '{{ aws_profile }}'
 
     - name: call optional notifier
-      include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+      include_role:
+        name: '{{ notifier_role }}'
       vars:
         message: >
           enabled logging on the Default trail in

--- a/tasks/deactivate.yml
+++ b/tasks/deactivate.yml
@@ -23,7 +23,8 @@
                        --profile {{ aws_profile }}
 
     - name: call optional notifier
-      include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+      include_role:
+        name: '{{ notifier_role }}'
       vars:
         message: >
           deleted the Default trail in

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,8 @@
     _aws_cloudtrail_url: https://console.aws.amazon.com/cloudtrail/home
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       started running role <b>aws-cloudtrail</b>
@@ -25,7 +26,8 @@
   with_items: '{{ _aws_cloudtrail_inactive_regions }}'
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       finished running role <b>aws-cloudtrail</b>


### PR DESCRIPTION
This is the proper way to include tasks from another role with modern Ansible.